### PR TITLE
feat(bills): Add usePostBillReference

### DIFF
--- a/src/config/constants/queryKeys.ts
+++ b/src/config/constants/queryKeys.ts
@@ -9,4 +9,5 @@ export const QUERY_KEYS = {
   TVL_STATS: 'tvlStats',
   TOKEN_HISTORIC: 'tokenHistoric',
   BONDS_LANDING: 'bondsLanding',
+  BOND_POST_REFERENCE: 'bondPostReference',
 }

--- a/src/state/bills/README-bills-api.md
+++ b/src/state/bills/README-bills-api.md
@@ -1,0 +1,43 @@
+# Bills API
+
+## POST `/bills/widget`
+
+### Body
+
+```typescript
+export class WidgetTransactionDTO {
+  chainId: number;
+  transactionHash: string;
+  referenceId: number;
+}
+```
+
+### POST HTTP Codes
+
+- `CONFLICT | 409` if transactionHash already exists.
+- `CREATED | 201` if tx is successfully created in the DB.
+- `INTERNAL_SERVER_ERROR | 500` if any error happens.
+
+## GET `/bills/widget`
+
+### Params
+
+```typescript
+export class WidgetTransactionFilterDTO {
+  chainId?: number;
+  referenceId?: number;
+  from?: number | Date;
+  to?: number | Date;
+}
+```
+
+### GET HTTP Codes
+
+- `OK | 200` if it founds transactions.
+- `NOT_FOUND | 404` if it doesn't found transactions.
+- `INTERNAL_SERVER_ERROR | 500` if any error happens.
+
+### Notes
+
+- All params are optional. If any, it will return all transactions.
+- Date `from` and `to` is in Epoch Unix Timestamp with ms (1692738000000)

--- a/src/state/bills/usePostBillReference.ts
+++ b/src/state/bills/usePostBillReference.ts
@@ -1,0 +1,67 @@
+import axiosRetry from 'axios-retry'
+import axios from 'axios'
+import { apiV2BaseUrl } from 'config/constants/api'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { QUERY_KEYS } from 'config/constants/queryKeys'
+import { useWeb3React } from '@web3-react/core'
+
+export interface BillReferenceData {
+  chainId: number
+  transactionHash: string
+  referenceId: string
+}
+
+export interface BillReferenceResponse {
+  chainId: number;
+  transactionHash: string;
+  referenceId: string;
+  createdAt: number;
+}
+
+export const postBillReference = async (data: BillReferenceData): Promise<BillReferenceResponse> => {
+  try {
+    axiosRetry(axios, {
+      retries: 2,
+      retryCondition: () => true,
+    })
+    const response = await axios.post(`${apiV2BaseUrl}/bills/widget`, data)
+    const billReferenceResp = await response.data
+
+    if(response.status !== 201) {
+      if(response.status === 409) {
+        throw new Error(`postBillReference: 409 tx-hash already exists for data ${data}`)
+      }
+      throw new Error(`postBillReference: Status not 201 for data ${data}. Status: ${response.status}`)
+    }
+    
+    return billReferenceResp
+  } catch (error) {
+    throw new Error(`postBillReference: error posting data ${data}`)
+  }
+}
+
+export const usePostBillReference = () => {
+  const queryClient = useQueryClient();
+  const { chainId: currentChainId } = useWeb3React()
+
+  return useMutation({
+    mutationFn: ({ chainId, transactionHash, referenceId }: Partial<BillReferenceData>) => {
+      chainId = chainId || currentChainId
+      if (!chainId || !transactionHash || !referenceId) {
+        throw new Error('usePostBillReference: Missing required keys in data')
+      }
+      return postBillReference({ chainId, transactionHash, referenceId })
+    },
+    onError: (error, variables, context) => {
+      console.error(`usePostBillReference: error posting data ${variables}, context: ${context} error: ${error}`)
+    },
+    onSuccess: () => {
+      // will wait for query invalidation to finish,
+      // mutation state will stay loading while related queries update
+      return queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.BOND_POST_REFERENCE],
+      })
+    },
+  })
+};
+

--- a/src/views/BondWidget/index.tsx
+++ b/src/views/BondWidget/index.tsx
@@ -7,6 +7,7 @@ import state from '../../state'
 import { APESWAP } from '../../config/constants/lists'
 import { SupportedChainId } from '@ape.swap/sdk-core'
 import AccountLoggedIn from '../../components/NavBarNew/components/Account/AccountLoggedIn'
+import { BillReferenceData, usePostBillReference } from 'state/bills/usePostBillReference'
 
 const BondWidget = ({
   capturedBillAddress,
@@ -15,12 +16,25 @@ const BondWidget = ({
   capturedBillAddress: string
   capturedChain: SupportedChainId
 }) => {
-  const { account } = useWeb3React()
+  const { account, chainId } = useWeb3React()
   const bills: Bills[] | undefined = useBills()
   const bill: Bills | undefined = bills?.find(
     (billToSearch) => billToSearch?.contractAddress?.[capturedChain] === capturedBillAddress,
   )
   const isApeListInitialized = typeof state?.getState()?.lists?.byUrl?.[APESWAP]?.current?.tokens?.length === 'number'
+
+  const { mutate: postBillReference, isLoading, isError } = usePostBillReference()
+  // TODO: Replace this test code with params from the widget config
+  // This can be tested using the following code:
+  // <button onClick={handleBuyReference} disabled={isLoading}>Test Post Data</button> 
+  const billsReference: Partial<BillReferenceData> = {
+    chainId,
+    transactionHash: '1234',
+    referenceId: 'TEST-REF'
+  }
+  const handleBuyReference = () => {
+    postBillReference(billsReference);
+  }
 
   return (
     <Flex


### PR DESCRIPTION
Add a hook to be able to post a bond purchase with a reference id to the backend. 

Current api testing is being handled here: https://apeswap-api-v2-pr-123.herokuapp.com 